### PR TITLE
Cap image size at 60% of viewport

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,9 +110,9 @@
     function setStatus(msg) { statusEl.textContent = msg; }
 
     function fitImageRect(imgW, imgH, viewW, viewH) {
-      // Cap image size for readability
-      const maxW = viewW * 0.9;
-      const maxH = viewH * 0.7;
+      // Cap image size for readability (60% of viewport)
+      const maxW = viewW * 0.6;
+      const maxH = viewH * 0.6;
       const scale = Math.min(maxW / imgW, maxH / imgH);
       const w = Math.max(1, Math.floor(imgW * scale));
       const h = Math.max(1, Math.floor(imgH * scale));


### PR DESCRIPTION
## Summary
- Limit uploaded image to 60% of viewport width and height for improved readability

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b396f206c0833098bea6564eb92b63